### PR TITLE
go.sum: update dependency checksums

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -144,9 +144,11 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.23/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
-github.com/ethersphere/bee v0.5.3 h1:/CbqmFwUYuketq3lfb+3waEi9pM3rQyEVMu3yBHoRrE=
-github.com/ethersphere/bee v0.5.3/go.mod h1:VYxqKlm0jveiqdPWwzinMFnWVwPBvOxQaLJ8qyHrU1A=
+github.com/ethersphere/bee v0.6.0 h1:hl8I5T0Lr0UlYBwk0TnnYSjmI9P02w5YXX8TXvFMp0o=
+github.com/ethersphere/bee v0.6.0/go.mod h1:pi1KvKq6cgc6h3V9hvIYFcfSNEnx3K0uZlW20UesVzI=
 github.com/ethersphere/bmt v0.1.4/go.mod h1:Yd8ft1U69WDuHevZc/rwPxUv1rzPSMpMnS6xbU53aY8=
+github.com/ethersphere/go-storage-incentives-abi v0.2.0/go.mod h1:SXvJVtM4sEsaSKD0jc1ClpDLw8ErPoROZDme4Wrc/Nc=
+github.com/ethersphere/go-sw3-abi v0.4.0/go.mod h1:BmpsvJ8idQZdYEtWnvxA8POYQ8Rl/NhyCdF0zLMOOJU=
 github.com/ethersphere/langos v1.0.0/go.mod h1:dlcN2j4O8sQ+BlCaxeBu43bgr4RQ+inJ+pHwLeZg5Tw=
 github.com/ethersphere/manifest v0.3.6/go.mod h1:frSxQFT67hQvmTN5CBtgVuqHzGQpg0V0oIIm/B3Am+U=
 github.com/ethersphere/sw3-bindings/v3 v3.0.3/go.mod h1:EEn7sxejLPj6p1oDT/YGrjDfNV8z6PWcd4DviE0hOIk=
@@ -261,6 +263,7 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=


### PR DESCRIPTION
Change auto-generated by running:

    go build -v pkg/main.go

The `bee` dep has changed (obviously); and there seem to be some new ones - according to `go mod graph | grep $TUFF`, this is where they come from:

```
...
github.com/ethersphere/bee@v0.6.0 github.com/ethersphere/go-storage-incentives-abi@v0.2.0
...
github.com/ethersphere/bee@v0.6.0 github.com/ethersphere/go-sw3-abi@v0.4.0
...
github.com/hashicorp/go-multierror@v1.1.1 github.com/hashicorp/errwrap@v1.0.0
github.com/hashicorp/memberlist@v0.1.3 github.com/hashicorp/go-multierror@v1.0.0
github.com/mitchellh/cli@v1.0.0 github.com/hashicorp/go-multierror@v1.0.0
github.com/ethersphere/bee@v0.6.0 github.com/hashicorp/go-multierror@v1.1.1
github.com/hashicorp/go-multierror@v1.0.0 github.com/hashicorp/errwrap@v1.0.0
...
```
